### PR TITLE
Column name 'End ' in GenomeCleanData.csv has a space 

### DIFF
--- a/Data_Quality/Clean_Data/GenomeCleanData.csv
+++ b/Data_Quality/Clean_Data/GenomeCleanData.csv
@@ -1,4 +1,4 @@
-﻿SeqName,Source,Feature,Start,End ,Score,Strand,Frame ,Attribute ,Genome String
+﻿SeqName,Source,Feature,Start,End,Score,Strand,Frame ,Attribute ,Genome String
 NC_045512v2,ncbiGenes.genePred,transcript,266,13483,.,+,.,"gene_id ""ORF1a""; transcript_id ""ORF1a""; ","TAAGATGGAGAGCCTTGTCCCTGGTTTCAACGAGAAAAC
 ACACGTCCAACTCAGTTTGCCTGTTTTACAGGTTCGCGACGTGCTCGTAC
 GTGGCTTTGGAGACTCCGTGGAGGAGGTCTTATCAGAGGCACGTCAACAT


### PR DESCRIPTION
Column name 'End ' in GenomeCleanData.csv has a space which results in errors while analyzing the data. 